### PR TITLE
instarepo automatic PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <!--
     dependencies for maven plugins
     -->
-    <maven-core.version>3.6.3</maven-core.version>
+    <maven-core.version>3.8.3</maven-core.version>
     <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
     <!--
     jacoco thresholds

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,7 @@
   <parent>
     <groupId>com.github.ngeor</groupId>
     <artifactId>java</artifactId>
-    <version>1.11.0-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
+    <version>2.0.0</version>
   </parent>
   <artifactId>yak4j-json-yaml-converter-maven-plugin</artifactId>
   <version>0.9.0-SNAPSHOT</version>


### PR DESCRIPTION
The following fixes have been applied:
- Corrected parent pom reference
- Updated Maven dependencies
  Major version changes allowed
  Updated ${maven-core.version} from 3.6.3 to 3.8.3
  Major version changes allowed
  Property ${maven-plugin-plugin.version}: Leaving unchanged as 3.6.0
  Major version changes allowed
  Property ${maven-invoker-plugin.version}: Leaving unchanged as 3.2.1
